### PR TITLE
fix: prevent stale app setting UI when reverting to defaults

### DIFF
--- a/src/hooks/appSetting-provider.tsx
+++ b/src/hooks/appSetting-provider.tsx
@@ -33,8 +33,10 @@ export const AppSettingProvider = ({ children }: AppSettingProviderProps) => {
             [key: string]: Browser.Storage.StorageChange;
         }) => {
             if (changes.appSetting) {
-                if (JSON.stringify(changes.appSetting.newValue) !== JSON.stringify(appSetting))
-                    setAppSetting(changes.appSetting.newValue as AppSettingType);
+                const newValue = changes.appSetting.newValue as AppSettingType;
+                setAppSetting((prev) =>
+                    JSON.stringify(newValue) !== JSON.stringify(prev) ? newValue : prev
+                );
             }
         };
         window.browser.storage.local.onChanged.addListener(onStorageChangeListener);


### PR DESCRIPTION
Compare storage changes against previous state via functional setState
so settings that match the initial defaults still update the UI.
