### PR TITLE
fix: remove invalid items-center from collection item title layouts

### DIFF
--- a/src/features/collections/item/Collection.tsx
+++ b/src/features/collections/item/Collection.tsx
@@ -95,7 +95,7 @@ const Collection = ({
                             >
                                 <Plus />
                             </Button>
-                            <div className="flex flex-col items-center justify-center p-2">
+                            <div className="flex flex-col justify-center p-2">
                                 <span className="truncate text-lg" title={item.title}>
                                     {item.title}
                                 </span>

--- a/src/features/collections/item/CollectionItem.tsx
+++ b/src/features/collections/item/CollectionItem.tsx
@@ -154,7 +154,7 @@ const CollectionItem = (props: PropType) => {
                             }}
                         />
                     </div>
-                    <div className="flex flex-col items-center justify-center p-2">
+                    <div className="flex flex-col justify-center p-2">
                         <span className="truncate text-lg" title={props.title}>
                             {props.title}
                         </span>


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [ ] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] I have linked any related issues (if applicable).
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**
