### PR TITLE
feat: warn signed-out users that collections are local-only

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,20 +1,22 @@
 ## v2.6.0
 
+![v2.6.0 feature walkthrough](github/v2.6.0-changelog.gif)
+
 ### Localization & docs
 
 - added: multi-language support with i18next (English / Spanish(incomplete) / French)
-- added: French translation by @swirti (#29, #30)
+- added: French translation by [@swirti](https://github.com/swirti) ([#29](https://github.com/mienaiyami/collection-extension-2.0/issues/29), [#30](https://github.com/mienaiyami/collection-extension-2.0/pull/30))
 - added: Discord invite link in the README
 
 ### Fixes
 
 - fixed: sync alarm scheduling after the v2.5.1 release
-- fixed: stale app setting UI when reverting to defaults (#31)
-- fixed: invalid `items-center` on collection item title layouts (#32)
+- fixed: stale app setting UI when reverting to defaults ([#31](https://github.com/mienaiyami/collection-extension-2.0/issues/31))
+- fixed: invalid `items-center` on collection item title layouts ([#32](https://github.com/mienaiyami/collection-extension-2.0/issues/32))
 
 ### Collections — search, sort & multi-select
 
-- added: search and sort on the collections list and inside a collection, with a collapsible filters panel (based on work by @shanksxz in `feat/search-and-sort`)
+- added: search and sort on the collections list and inside a collection, with a collapsible filters panel (based on work by [@shanksxz](https://github.com/shanksxz) in `feat/search-and-sort`)
 - added: collection list search modes — title only, or title + items (deep), with a hint when the match is from nested items only
 - added: sort by default (manual), name, modified, date (plus item count on the list), with ascending/descending; drag-reorder only when search is empty and sort is default
 - added: multi-select collections (checkbox, Shift+click range, Ctrl+A for visible rows) with batch open, copy, and delete (delete requires confirmation)
@@ -23,18 +25,16 @@
 
 ### Collections — edit item
 
-- added: edit collection item title, URL, and image (URL, file upload, or clipboard paste) from the item context menu (#35); closes #22
+- added: edit collection item title, URL, and image (URL, file upload, or clipboard paste) from the item context menu ([#35](https://github.com/mienaiyami/collection-extension-2.0/issues/35)); closes [#22](https://github.com/mienaiyami/collection-extension-2.0/issues/22)
 
 ### Collections — duplicates
 
-- added: remove duplicate URLs within a collection (keep most recent or oldest) from selection overflow menus and collection context menu (#10)
-- added: settings toggle to auto-remove older duplicate URLs when adding a link to a collection (#10)
+- added: remove duplicate URLs within a collection (keep most recent or oldest) from selection overflow menus and collection context menu ([#10](https://github.com/mienaiyami/collection-extension-2.0/issues/10))
+- added: settings toggle to auto-remove older duplicate URLs when adding a link to a collection ([#10](https://github.com/mienaiyami/collection-extension-2.0/issues/10))
 
----
+### Sync
 
-Demo walkthrough:
-
-![v2.6.0 feature walkthrough](github/v2.6.0-changelog.gif)
+- added: danger-styled SyncStatus tooltip for signed-out users warning that collections are local-only (not browser online sync) and can be lost if the browser session ends or the extension is removed
 
 ## v2.5.1
 

--- a/src/features/layout/SyncStatus.tsx
+++ b/src/features/layout/SyncStatus.tsx
@@ -15,6 +15,7 @@ const getIcon = (status: SyncState["status"] | undefined) => {
         case "syncing":
             return <RefreshCw className="animate-spin text-blue-500" />;
         case "error":
+        case "not-authenticated":
             return <CloudOff className="text-destructive" />;
         case "unsynced":
             return <CloudOff className="text-yellow-500" />;
@@ -23,13 +24,18 @@ const getIcon = (status: SyncState["status"] | undefined) => {
     }
 };
 
-const getTooltipContent = (
-    syncState: SyncState | null,
-    t: TFunction
-): {
+type SyncTooltipContent = {
     message: string;
     details: string;
-} => {
+    /** Danger styling for local-only / not-logged-in warnings. */
+    danger?: boolean;
+};
+
+/**
+ * Builds SyncStatus tooltip copy from the current sync state.
+ * Unauthenticated users get a local-data loss warning (danger).
+ */
+const getTooltipContent = (syncState: SyncState | null, t: TFunction): SyncTooltipContent => {
     if (syncState === null)
         return {
             message: t("sync.statusUnknown"),
@@ -62,7 +68,8 @@ const getTooltipContent = (
         case "not-authenticated":
             return {
                 message: t("sync.notAuthenticated"),
-                details: t("sync.pleaseLoginToSync"),
+                details: t("sync.localDataWarning"),
+                danger: true,
             };
         default:
             return {
@@ -119,11 +126,17 @@ export const SyncStatus = () => {
                     </Button>
                 </span>
             </TooltipTrigger>
-            <TooltipContent className="max-w-xs text-center">
-                <div className="flex flex-col items-start">
+            <TooltipContent
+                className={
+                    tooltipContent.danger
+                        ? "max-w-xs border-destructive bg-destructive text-center text-destructive-foreground"
+                        : "max-w-xs text-center"
+                }
+            >
+                <div className="flex flex-col items-start gap-1 text-left">
                     <span className="font-semibold">{tooltipContent.message}</span>
                     {tooltipContent.details && (
-                        <span className="text-sm">{tooltipContent.details}</span>
+                        <span className="text-sm opacity-95">{tooltipContent.details}</span>
                     )}
                 </div>
             </TooltipContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -247,7 +247,7 @@
         "notAuthenticated": "Not authenticated",
         "statusUnknown": "Sync status unknown",
         "tryLoggingInAgain": "Try logging in again.",
-        "pleaseLoginToSync": "Please login to sync.",
+        "localDataWarning": "Collections are stored only in this browser (local), not in browser online sync. Signing out or removing the extension can permanently delete them. Optionally log in with Google Drive from Settings to sync/backup.",
         "changesNotSynced": "Changes not synced",
         "lastSynced": "Last synced: {{time}}",
         "clickToSync": "Click to sync now"

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -247,7 +247,7 @@
         "notAuthenticated": "Not authenticated",
         "statusUnknown": "Sync status unknown",
         "tryLoggingInAgain": "Try logging in again.",
-        "pleaseLoginToSync": "Please login to sync.",
+        "localDataWarning": "Collections are stored only in this browser (local), not in browser online sync. Signing out or removing the extension can permanently delete them. Optionally log in with Google Drive from Settings to sync/backup.",
         "changesNotSynced": "Changes not synced",
         "lastSynced": "Last synced: {{time}}",
         "clickToSync": "Click to sync now"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -247,7 +247,7 @@
         "notAuthenticated": "Non authentifié",
         "statusUnknown": "Statut de synchronisation inconnu",
         "tryLoggingInAgain": "Essayez de vous reconnecter.",
-        "pleaseLoginToSync": "Veuillez vous connecter pour synchroniser.",
+        "localDataWarning": "Collections are stored only in this browser (local), not in browser online sync. Signing out or removing the extension can permanently delete them. Optionally log in with Google Drive from Settings to sync/backup.",
         "changesNotSynced": "Modifications non synchronisées",
         "lastSynced": "Dernière synchronisation : {{time}}",
         "clickToSync": "Cliquez pour synchroniser maintenant"


### PR DESCRIPTION

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [ ] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] I have linked any related issues (if applicable).
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**
Show a danger SyncStatus tooltip when not authenticated, clarifying data is not in browser online sync and can be lost on logout or uninstall.
