### PR TITLE
fix: normalize appSetting so collectionListView.sortBy is never undefined

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,10 @@
+## Unreleased
+
+- feat: danger-styled SyncStatus tooltip for signed-out users warning that collections are local-only (not browser online sync) and can be lost if the browser session ends or the extension is removed ([#42](https://github.com/mienaiyami/collection-extension-2.0/pull/42))
+- fix: Collection View crash (`sortBy` of undefined) for users whose saved app settings predate search/sort fields — normalize `appSetting` on load and when writing/migrating settings so `collectionListView` / `collectionItemView` defaults are always present
+- improved: vertical divider between “New empty” and “New from opened tabs” on the collections list toolbar (same pattern as Collection Item View)
+- chore **dev**: add release guide and update contribution docs
+
 ## v2.6.0
 
 ![v2.6.0 feature walkthrough](github/v2.6.0-changelog.gif)
@@ -31,10 +38,6 @@
 
 - added: remove duplicate URLs within a collection (keep most recent or oldest) from selection overflow menus and collection context menu ([#10](https://github.com/mienaiyami/collection-extension-2.0/issues/10))
 - added: settings toggle to auto-remove older duplicate URLs when adding a link to a collection ([#10](https://github.com/mienaiyami/collection-extension-2.0/issues/10))
-
-### Sync
-
-- added: danger-styled SyncStatus tooltip for signed-out users warning that collections are local-only (not browser online sync) and can be lost if the browser session ends or the extension is removed
 
 ## v2.5.1
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -14,11 +14,11 @@ import type {
     MessageResponse,
 } from "./types/messages";
 import {
-    appSettingSchema,
     collectionSchema,
     deletedCollectionItemSchema,
     getDataFromTab,
     initAppSetting,
+    normalizeAppSetting,
     wait,
 } from "./utils";
 import "./i18n/config"; // Import i18n configuration
@@ -139,14 +139,11 @@ browser.runtime.onInstalled.addListener((e) => {
         (() => {
             browser.storage.local.get("appSetting").then(({ appSetting }) => {
                 if (appSetting) {
-                    if (
-                        !(appSetting as AppSettingType).version ||
-                        (appSetting as AppSettingType).version < initAppSetting.version
-                    ) {
-                        const newSettings = appSettingSchema.parse(appSetting);
-                        browser.storage.local.set({
-                            appSetting: newSettings,
-                        });
+                    /* Parse on every update so new defaulted fields are filled even
+                     * when version was not bumped (collectionListView, etc.). */
+                    const { setting, persist } = normalizeAppSetting(appSetting);
+                    if (persist) {
+                        browser.storage.local.set({ appSetting: setting });
                     }
                 }
             });
@@ -872,14 +869,16 @@ class CollectionManager {
     static async updateAppSetting(
         update: Partial<AppSettingType>
     ): CollectionOperationResponse<"SET_APP_SETTING"> {
-        const { appSetting } = (await browser.storage.local.get("appSetting")) as {
-            appSetting: AppSettingType;
-        };
+        const { appSetting } = await browser.storage.local.get("appSetting");
         if (!appSetting) {
             return { success: false, error: "App setting not found" };
         }
-        const newSetting = { ...appSetting, ...update };
-        await browser.storage.local.set({ appSetting: newSetting });
+        /* Normalize after shallow merge so nested patches never persist a half-object. */
+        const { setting } = normalizeAppSetting({
+            ...(appSetting as AppSettingType),
+            ...update,
+        });
+        await browser.storage.local.set({ appSetting: setting });
         return { success: true };
     }
 }

--- a/src/features/collections/view/CollectionView.tsx
+++ b/src/features/collections/view/CollectionView.tsx
@@ -18,6 +18,7 @@ import {
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
 import { useRemoveDuplicatesDialog } from "@/features/collections/duplicates/use-remove-duplicates-dialog";
 import {
     applyRangeSelection,
@@ -176,7 +177,7 @@ const CollectionView = () => {
                     <SearchSortControls {...controlsProps} />
 
                     {selected.length === 0 ? (
-                        <div className="grid h-12 grid-cols-2 items-center border-border border-b p-1">
+                        <div className="grid h-12 grid-cols-[1fr_1px_1fr] items-center border-border border-b p-1">
                             <Button
                                 variant={"ghost"}
                                 onClick={async () => {
@@ -190,6 +191,7 @@ const CollectionView = () => {
                             >
                                 {t("collections.newEmpty")}
                             </Button>
+                            <Separator orientation="vertical" />
                             <Button
                                 variant={"ghost"}
                                 onClick={async () => {

--- a/src/hooks/appSetting-provider.tsx
+++ b/src/hooks/appSetting-provider.tsx
@@ -1,4 +1,4 @@
-import { initAppSetting } from "@/utils";
+import { initAppSetting, normalizeAppSetting } from "@/utils";
 import { createContext, useContext, useLayoutEffect, useState } from "react";
 import type Browser from "webextension-polyfill";
 
@@ -25,17 +25,23 @@ export const AppSettingProvider = ({ children }: AppSettingProviderProps) => {
 
     useLayoutEffect(() => {
         window.browser.storage.local.get().then(({ appSetting: _appSetting }) => {
-            if (_appSetting && Object.keys(_appSetting).includes("version"))
-                setAppSetting(_appSetting as AppSettingType);
-            else window.browser.storage.local.set({ appSetting });
+            if (_appSetting && typeof _appSetting === "object" && "version" in _appSetting) {
+                const { setting, persist } = normalizeAppSetting(_appSetting);
+                setAppSetting(setting);
+                /* One-shot heal so legacy blobs gain collectionListView / etc. */
+                if (persist) {
+                    void window.browser.storage.local.set({ appSetting: setting });
+                }
+            } else window.browser.storage.local.set({ appSetting });
         });
         const onStorageChangeListener = (changes: {
             [key: string]: Browser.Storage.StorageChange;
         }) => {
             if (changes.appSetting) {
-                const newValue = changes.appSetting.newValue as AppSettingType;
+                /* Normalize for UI only — do not write here (multi-context write storms). */
+                const { setting } = normalizeAppSetting(changes.appSetting.newValue);
                 setAppSetting((prev) =>
-                    JSON.stringify(newValue) !== JSON.stringify(prev) ? newValue : prev
+                    JSON.stringify(setting) !== JSON.stringify(prev) ? setting : prev
                 );
             }
         };

--- a/src/utils.schema.test.ts
+++ b/src/utils.schema.test.ts
@@ -1,32 +1,40 @@
 import { describe, expect, it, vi } from "vitest";
-import { appSettingSchema, collectionItemSchema, collectionSchema } from "./utils";
+import {
+    appSettingSchema,
+    collectionItemSchema,
+    collectionSchema,
+    initAppSetting,
+    normalizeAppSetting,
+} from "./utils";
 
 vi.mock("webextension-polyfill", () => ({
     default: {},
 }));
 
+const fullAppSettingDefaults = {
+    version: 1,
+    font: {
+        size: 16,
+        family: "Inter",
+    },
+    copyDataFormat: "{{url}}",
+    autoRemoveDuplicateUrls: false,
+    collectionListView: {
+        searchMode: "title",
+        sortBy: "default",
+        sortDir: "asc",
+        filtersOpen: false,
+    },
+    collectionItemView: {
+        sortBy: "default",
+        sortDir: "asc",
+        filtersOpen: false,
+    },
+};
+
 describe("appSettingSchema", () => {
     it("applies defaults for an empty object", () => {
-        expect(appSettingSchema.parse({})).toEqual({
-            version: 1,
-            font: {
-                size: 16,
-                family: "Inter",
-            },
-            copyDataFormat: "{{url}}",
-            autoRemoveDuplicateUrls: false,
-            collectionListView: {
-                searchMode: "title",
-                sortBy: "default",
-                sortDir: "asc",
-                filtersOpen: false,
-            },
-            collectionItemView: {
-                sortBy: "default",
-                sortDir: "asc",
-                filtersOpen: false,
-            },
-        });
+        expect(appSettingSchema.parse({})).toEqual(fullAppSettingDefaults);
     });
 
     it("fills collection view defaults when older settings omit them", () => {
@@ -47,6 +55,63 @@ describe("appSettingSchema", () => {
                 sortBy: "default",
                 filtersOpen: false,
             },
+        });
+    });
+});
+
+describe("normalizeAppSetting", () => {
+    it("fills defaults when older settings omit list/item view and autoRemoveDuplicateUrls", () => {
+        const result = normalizeAppSetting({
+            version: 1,
+            font: { size: 16, family: "Inter" },
+            copyDataFormat: "{{url}}",
+        });
+        expect(result.setting).toEqual(fullAppSettingDefaults);
+        expect(result.persist).toBe(true);
+    });
+
+    it("defaults missing nested collectionListView fields", () => {
+        const result = normalizeAppSetting({
+            version: 1,
+            font: { size: 16, family: "Inter" },
+            copyDataFormat: "{{url}}",
+            collectionListView: { sortBy: "name" },
+        });
+        expect(result.setting).toMatchObject({
+            collectionListView: {
+                searchMode: "title",
+                sortBy: "name",
+                sortDir: "asc",
+                filtersOpen: false,
+            },
+            collectionItemView: {
+                sortBy: "default",
+                sortDir: "asc",
+                filtersOpen: false,
+            },
+            autoRemoveDuplicateUrls: false,
+        });
+        expect(result.persist).toBe(true);
+    });
+
+    it("does not ask to persist when settings are already complete", () => {
+        const result = normalizeAppSetting(fullAppSettingDefaults);
+        expect(result.setting).toEqual(fullAppSettingDefaults);
+        expect(result.persist).toBe(false);
+    });
+
+    it("falls back to initAppSetting for invalid input without persist", () => {
+        expect(normalizeAppSetting(null)).toEqual({
+            setting: initAppSetting,
+            persist: false,
+        });
+        expect(normalizeAppSetting("broken")).toEqual({
+            setting: initAppSetting,
+            persist: false,
+        });
+        expect(normalizeAppSetting({ version: "not-a-number" })).toEqual({
+            setting: initAppSetting,
+            persist: false,
         });
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,6 +227,33 @@ export const appSettingSchema = z
     .strip();
 export const initAppSetting = appSettingSchema.parse({});
 
+type NormalizedAppSetting = z.infer<typeof appSettingSchema>;
+
+type NormalizeAppSettingResult = {
+    setting: NormalizedAppSetting;
+    /**
+     * True when `raw` parsed and differs from the filled result (e.g. new defaults).
+     * False on parse failure — do not overwrite storage with {@link initAppSetting}.
+     */
+    persist: boolean;
+};
+
+/**
+ * Coerces storage/raw settings into a full app setting object.
+ * Call at storage trust boundaries (provider load, background write/migrate)
+ * so consumers never see missing nested fields like `collectionListView.sortBy`.
+ */
+export const normalizeAppSetting = (raw: unknown): NormalizeAppSettingResult => {
+    const parsed = appSettingSchema.safeParse(raw);
+    if (!parsed.success) {
+        return { setting: initAppSetting, persist: false };
+    }
+    return {
+        setting: parsed.data,
+        persist: JSON.stringify(parsed.data) !== JSON.stringify(raw),
+    };
+};
+
 // version<=v2.4.2: data is on every item, adding createdAt,updatedAt,deleted now;
 export const collectionItemSchema = z
     .object({


### PR DESCRIPTION

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](../docs/contribute.md) for this project.
- [ ] I agree to follow the [code of conduct](../CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] I have linked any related issues (if applicable).
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The changes does not disrupt the app in other supported OS.

**Summarize your changes:**


Legacy storage blobs with version but no collectionListView crashed Collection View. Parse at provider load and on background write/migrate.
